### PR TITLE
Remove the snap-extras dependency & add stack support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ log/
 logs/
 plugin/
 *.png
+*.svg
+.stack-work/

--- a/peacoq.cabal
+++ b/peacoq.cabal
@@ -40,7 +40,6 @@ Executable peacoq
     random                    >= 1.0   && < 1.2,
     snap                      >= 0.14  && < 0.15,
     snap-core                 >= 0.9   && < 0.10,
-    snap-extras               >= 0.11  && < 0.12,
     snap-server               >= 0.9   && < 0.10,
     tagsoup                   >= 0.13  && < 0.14,
     text                      >= 1.2   && < 1.3,

--- a/src/Snap/Extras/JSON.hs
+++ b/src/Snap/Extras/JSON.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+
+module Snap.Extras.JSON
+    (
+    -- * Sending JSON Data
+    writeJSON
+    ) where
+
+
+-------------------------------------------------------------------------------
+import           Data.Aeson            as A
+import           Snap.Core
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- | Mark response as 'application/json'
+jsonResponse :: MonadSnap m => m ()
+jsonResponse = modifyResponse $ setHeader "Content-Type" "application/json"
+
+
+-------------------------------------------------------------------------------
+-- | Set MIME to 'application/json' and write given object into
+-- 'Response' body.
+writeJSON :: (MonadSnap m, ToJSON a) => a -> m ()
+writeJSON a = do
+  jsonResponse
+  writeLBS . encode $ a

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+extra-deps: []
+resolver: lts-3.8
+flags: {}
+packages:
+- '.'


### PR DESCRIPTION
snap-extras required the native pcre library to be installed, which made me lots of problems installing PeaCoq on windows.
I added the single function that PeaCoq uses from this library and removed the dependency.

In addition, I added a clean `stack.yaml` file to the project.
