### PR TITLE
fix a few things in .nix files

### DIFF
--- a/peacoq.cabal
+++ b/peacoq.cabal
@@ -2,7 +2,7 @@ Name:                peacoq
 Version:             0.1
 Synopsis:            PeaCoq is a web front-end to Coq
 Description:         PeaCoq is still a web front-end to Coq
-License:             BSD3
+License:             MIT
 Author:              Valentin Robert
 Maintainer:          vrobert@cs.ucsd.edu
 Stability:           Experimental

--- a/peacoq.nix
+++ b/peacoq.nix
@@ -19,5 +19,5 @@ mkDerivation {
     utf8-string xml-conduit xml-types
   ];
   description = "PeaCoq is a web front-end to Coq";
-  license = stdenv.lib.licenses.unfree;
+  license = stdenv.lib.licenses.mit;
 }

--- a/shell-build.nix
+++ b/shell-build.nix
@@ -26,7 +26,7 @@ let
         ];
         executableToolDepends = [ alex happy ];
         description = "PeaCoq is a web front-end to Coq";
-        license = stdenv.lib.licenses.bsd3;
+        license = stdenv.lib.licenses.mit;
       };
 
   haskellPackages = if compiler == "default"

--- a/shell-run.nix
+++ b/shell-run.nix
@@ -1,6 +1,6 @@
 with import <nixpkgs> {}; {
   peacoqPluginEnv = stdenv.mkDerivation {
     name = "peacoq-plugin";
-    buildInputs = [ coqPackages_8_5.coq ocaml ocamlPackages.camlp5_6_strict ];
+    buildInputs = [ coq ocaml ocamlPackages.camlp5_6_strict ];
   };
 }


### PR DESCRIPTION
Hey,

I have fixed what seemed to be obvious license errors and a dependency to Coq 8.5 while the README said Coq 8.4.

However I have not been able to test my code because it still breaks for other reasons.

Can the dependency to aeson be updated to a more recent version? It seems that the one installed by Nix is not among those listed in the peacoq.cabal file.

Théo

PS: Is master supposed to be compiling right now? If not, that may explain some of my troubles.
