### PR TITLE
Fix order of instructions in setup file

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -52,9 +52,9 @@ else
   ghc-pkg unregister peacoqtop || true
 fi
 
+check-and-clone "peacoq-plugin"
 ./scripts/setup-coq.sh
 ./scripts/setup-coq-serapi.sh
-check-and-clone "peacoq-plugin"
 (PATH=../coq/bin:$PATH && cd peacoq-plugin && make clean && make)
 
 log "Installing front-end dependencies"


### PR DESCRIPTION
`scripts/setup-coq.sh` is a symlink to a file that does not exist if we haven't cloned "peacoq-plugin"

I am still working on #38 but this is a first (independent) step.